### PR TITLE
Improve DSF path resolution with pathlib and support multi-digit volumes

### DIFF
--- a/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
+++ b/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
@@ -10,8 +10,8 @@ filesystem I/O for file uploads and downloads on the SBC.
 import asyncio
 import json
 import os
-import re
 import shutil
+from pathlib import Path, PurePosixPath
 from typing import AsyncIterable, AsyncIterator, BinaryIO, Callable, Optional
 
 import attr
@@ -34,9 +34,6 @@ FILE_IO_CHUNK_SIZE = 65536
 # Minimum DCS API version required
 MIN_DCS_API_VERSION = 8
 
-# Regex matching RRF volume prefixes like '0:', '1:', '10:', etc.
-_VOLUME_PREFIX_RE = re.compile(r'^\d+:')
-
 # Progress percentage upper bound
 PROGRESS_MAX = 100.0
 
@@ -55,17 +52,20 @@ def _resolve_dsf_path(filepath: str, base_dir: str) -> str:
     :return: Resolved absolute filesystem path
     """
     # Strip any RRF volume prefix (e.g. '0:', '1:', '10:')
-    filepath = _VOLUME_PREFIX_RE.sub('', filepath)
-    # Ensure leading slash for consistent joining
-    if filepath.startswith('/'):
-        filepath = filepath[1:]
-    resolved = os.path.join(base_dir, filepath)
-    # Prevent directory traversal
-    resolved = os.path.realpath(resolved)
-    base_real = os.path.realpath(base_dir)
-    if not resolved.startswith(base_real):
+    if ':' in filepath:
+        prefix, rest = filepath.split(':', 1)
+        if prefix.isdigit():
+            filepath = rest
+
+    relative = PurePosixPath(filepath)
+    if relative.root:
+        relative = relative.relative_to('/')
+
+    base = Path(base_dir).resolve()
+    resolved = (base / relative).resolve()
+    if not resolved.is_relative_to(base):
         raise ValueError(f'Path traversal detected: {filepath}')
-    return resolved
+    return str(resolved)
 
 
 class _SocketReceiver:

--- a/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
+++ b/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
@@ -10,6 +10,7 @@ filesystem I/O for file uploads and downloads on the SBC.
 import asyncio
 import json
 import os
+import re
 import shutil
 from typing import AsyncIterable, AsyncIterator, BinaryIO, Callable, Optional
 
@@ -33,8 +34,8 @@ FILE_IO_CHUNK_SIZE = 65536
 # Minimum DCS API version required
 MIN_DCS_API_VERSION = 8
 
-# RRF volume prefix length ('0:')
-VOLUME_PREFIX_LENGTH = 2
+# Regex matching RRF volume prefixes like '0:', '1:', '10:', etc.
+_VOLUME_PREFIX_RE = re.compile(r'^\d+:')
 
 # Progress percentage upper bound
 PROGRESS_MAX = 100.0
@@ -53,9 +54,8 @@ def _resolve_dsf_path(filepath: str, base_dir: str) -> str:
     :param base_dir: DSF SD card base directory (e.g. '/opt/dsf/sd')
     :return: Resolved absolute filesystem path
     """
-    # Strip the volume prefix '0:/' or '0:' if present
-    if filepath.startswith('0:'):
-        filepath = filepath[VOLUME_PREFIX_LENGTH:]
+    # Strip any RRF volume prefix (e.g. '0:', '1:', '10:')
+    filepath = _VOLUME_PREFIX_RE.sub('', filepath)
     # Ensure leading slash for consistent joining
     if filepath.startswith('/'):
         filepath = filepath[1:]

--- a/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
+++ b/meltingplot/duet_simplyprint_connector/duet/dsf_socket.py
@@ -51,15 +51,14 @@ def _resolve_dsf_path(filepath: str, base_dir: str) -> str:
     :param base_dir: DSF SD card base directory (e.g. '/opt/dsf/sd')
     :return: Resolved absolute filesystem path
     """
+    parts = PurePosixPath(filepath).parts
     # Strip any RRF volume prefix (e.g. '0:', '1:', '10:')
-    if ':' in filepath:
-        prefix, rest = filepath.split(':', 1)
-        if prefix.isdigit():
-            filepath = rest
-
-    relative = PurePosixPath(filepath)
-    if relative.root:
-        relative = relative.relative_to('/')
+    if parts and parts[0][0].isdigit():
+        parts = parts[1:]
+    # Strip leading /
+    if parts and parts[0] == '/':
+        parts = parts[1:]
+    relative = PurePosixPath(*parts) if parts else PurePosixPath()
 
     base = Path(base_dir).resolve()
     resolved = (base / relative).resolve()

--- a/tests/test_dsf_socket.py
+++ b/tests/test_dsf_socket.py
@@ -35,9 +35,25 @@ class TestResolveDsfPath:
         result = _resolve_dsf_path('0:/sys/config.g', '/opt/dsf/sd')
         assert result == '/opt/dsf/sd/sys/config.g'
 
+    def test_resolve_volume_1(self):
+        result = _resolve_dsf_path('1:/gcodes/test.gcode', '/opt/dsf/sd')
+        assert result == '/opt/dsf/sd/gcodes/test.gcode'
+
+    def test_resolve_volume_2(self):
+        result = _resolve_dsf_path('2:/gcodes/test.gcode', '/opt/dsf/sd')
+        assert result == '/opt/dsf/sd/gcodes/test.gcode'
+
+    def test_resolve_multi_digit_volume(self):
+        result = _resolve_dsf_path('10:/gcodes/test.gcode', '/opt/dsf/sd')
+        assert result == '/opt/dsf/sd/gcodes/test.gcode'
+
     def test_resolve_traversal_blocked(self):
         with pytest.raises(ValueError, match='Path traversal detected'):
             _resolve_dsf_path('0:/../../etc/passwd', '/opt/dsf/sd')
+
+    def test_resolve_traversal_blocked_other_volume(self):
+        with pytest.raises(ValueError, match='Path traversal detected'):
+            _resolve_dsf_path('10:/../../etc/passwd', '/opt/dsf/sd')
 
 
 # --- Socket receiver tests ---


### PR DESCRIPTION
## Summary
Refactored the `_resolve_dsf_path` function to use `pathlib` for more robust path handling and extended support for multi-digit RRF volume prefixes (e.g., '10:', '11:').

## Key Changes
- Replaced `os.path` operations with `pathlib.Path` and `PurePosixPath` for cleaner, more Pythonic path manipulation
- Updated volume prefix detection to support multi-digit volume numbers (previously only handled single-digit '0:')
- Improved path traversal detection using `Path.is_relative_to()` instead of string prefix matching
- Enhanced test coverage with additional test cases for multi-digit volumes and traversal attempts with different volume prefixes

## Implementation Details
- Uses `PurePosixPath.parts` to parse the filepath into components, making volume prefix detection more robust
- Removed the hardcoded `VOLUME_PREFIX_LENGTH` constant in favor of dynamic detection based on digit characters
- Path resolution now uses `Path.resolve()` for both base and target paths, ensuring consistent symlink resolution
- Return value is converted back to string for API compatibility

https://claude.ai/code/session_012nc96wu3LuQgsXq2zqj9Wy